### PR TITLE
feat(value): add is_function

### DIFF
--- a/src/engine/include/includejs/engine_value.h
+++ b/src/engine/include/includejs/engine_value.h
@@ -37,6 +37,7 @@ public:
   auto is_undefined() const -> bool;
   auto is_null() const -> bool;
   auto is_array() const -> bool;
+  auto is_function() const -> bool;
   auto to_number() const -> double;
   auto to_string() const -> std::string;
   auto to_boolean() const -> bool;

--- a/src/engine/javascript_core/engine_value.cc
+++ b/src/engine/javascript_core/engine_value.cc
@@ -131,6 +131,17 @@ auto Value::is_null() const -> bool {
   return JSValueIsNull(this->internal->context, this->internal->value);
 }
 
+auto Value::is_function() const -> bool {
+  if (!is_object()) {
+    return false;
+  }
+
+  JSObjectRef object =
+      get_current_object(this->internal->context, this->internal->value);
+
+  return JSObjectIsFunction(this->internal->context, object);
+}
+
 auto Value::to_number() const -> double {
   assert(is_number());
   JSValueRef exception = nullptr;

--- a/test/engine/CMakeLists.txt
+++ b/test/engine/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(includejs_engine_unit
   engine_stacktraces_test.cc
   engine_value_object_test.cc
   engine_value_array_test.cc
+  engine_value_function_test.cc
   engine_value_undefined_test.cc
   engine_value_null_test.cc)
 

--- a/test/engine/engine_value_function_test.cc
+++ b/test/engine/engine_value_function_test.cc
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+
+#include <includejs/engine.h>
+
+TEST(IncludeJS_Engine, is_function) {
+  sourcemeta::includejs::Engine engine;
+
+  auto obj = engine.context().make_object();
+  obj.set(
+      "foo",
+      [](std::vector<sourcemeta::includejs::Value> arguments)
+          -> sourcemeta::includejs::Value { return std::move(arguments[0]); });
+  obj.set("bar", engine.context().from(42));
+
+  EXPECT_TRUE(obj.at("foo").has_value());
+  EXPECT_TRUE(obj.at("foo").value().is_function());
+
+  EXPECT_TRUE(obj.at("bar").has_value());
+  EXPECT_FALSE(obj.at("bar").value().is_function());
+}


### PR DESCRIPTION
I did not add make_function as it doesn't make sense so far as the user will either:

- bind a function to the global object using bind APIs (engine)
- or attach it to an object using Value::set

And we could create this helper later if we found a use case :) 

But when it comes to bridging, having this `is_function` helper is handy :) 