### PR TITLE
Use ClangFormat 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         if: runner.os == 'linux'
         run: |
           sudo apt-get update --yes
-          sudo apt-get install --yes clang-format libjavascriptcoregtk-4.0-dev
+          sudo apt-get install --yes libjavascriptcoregtk-4.0-dev
 
       # See https://github.com/actions/runner-images/issues/8659
       - name: Workaround Clang issue (GNU/Linux)
@@ -98,6 +98,8 @@ jobs:
         env:
           HOMEBREW_NO_ANALYTICS: 1
           HOMEBREW_NO_AUTO_UPDATE: 1
+      - name: Install ClangFormat
+        run: pip install clang-format==18.1.0
       - run: cmake --version
       - name: Configure IncludeJS (static)
         if: matrix.platform.type == 'static'

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,3 @@
 brew "cmake"
-brew "clang-format"
 brew "doxygen"
 brew "v8"

--- a/src/engine/common/engine.cc
+++ b/src/engine/common/engine.cc
@@ -13,8 +13,8 @@
 namespace includejs {
 
 // For convenience
-auto Engine::evaluate(std::ifstream &stream, const std::filesystem::path &path)
-    -> Value {
+auto Engine::evaluate(std::ifstream &stream,
+                      const std::filesystem::path &path) -> Value {
   stream.exceptions(std::ios_base::badbit);
   std::string line;
   std::ostringstream result;

--- a/src/engine/include/includejs/engine.h
+++ b/src/engine/include/includejs/engine.h
@@ -29,22 +29,22 @@ public:
   ~Engine();
 
   auto evaluate(const std::filesystem::path &path) -> Value;
-  auto evaluate(const std::string &code, const std::filesystem::path &path)
-      -> Value;
-  auto evaluate(std::ifstream &stream, const std::filesystem::path &path)
-      -> Value;
+  auto evaluate(const std::string &code,
+                const std::filesystem::path &path) -> Value;
+  auto evaluate(std::ifstream &stream,
+                const std::filesystem::path &path) -> Value;
 
   // TODO(RaisinTen): Add support for bind_function() to the V8 backend.
 #if !defined(INCLUDEJS_ENGINE_V8)
   auto bind_function(std::initializer_list<std::string> location,
                      Function function) -> void;
 #endif
-  auto bind_global(std::initializer_list<std::string> location, Value value)
-      -> void;
-  auto bind_global(std::initializer_list<std::string> location, bool value)
-      -> void;
-  auto bind_global(std::initializer_list<std::string> location, int value)
-      -> void;
+  auto bind_global(std::initializer_list<std::string> location,
+                   Value value) -> void;
+  auto bind_global(std::initializer_list<std::string> location,
+                   bool value) -> void;
+  auto bind_global(std::initializer_list<std::string> location,
+                   int value) -> void;
   auto bind_global(std::initializer_list<std::string> location,
                    std::initializer_list<Value> values) -> void;
 

--- a/src/engine/include/includejs/engine_private_data.h
+++ b/src/engine/include/includejs/engine_private_data.h
@@ -17,8 +17,8 @@ struct INCLUDEJS_ENGINE_EXPORT PrivateObjectData {
   ~PrivateObjectData();
 
   auto data() -> void *;
-  auto set_data(void *new_data, std::function<void(void *)> new_deleter)
-      -> void;
+  auto set_data(void *new_data,
+                std::function<void(void *)> new_deleter) -> void;
 
 private:
   void *data_ = nullptr;

--- a/src/engine/javascript_core/engine.cc
+++ b/src/engine/javascript_core/engine.cc
@@ -144,8 +144,8 @@ auto Engine::bind_global(std::initializer_list<std::string> location,
   }
 }
 
-auto Engine::bind_global(std::initializer_list<std::string> location, int value)
-    -> void {
+auto Engine::bind_global(std::initializer_list<std::string> location,
+                         int value) -> void {
   JSValueRef exception = nullptr;
   JSValueRef js_value =
       JSValueMakeNumber(this->internal->context, static_cast<double>(value));

--- a/src/engine/javascript_core/engine_private_data.cc
+++ b/src/engine/javascript_core/engine_private_data.cc
@@ -6,9 +6,8 @@ PrivateObjectData::~PrivateObjectData() { clear(); }
 
 auto PrivateObjectData::data() -> void * { return data_; }
 
-auto PrivateObjectData::set_data(void *new_data,
-                                 std::function<void(void *)> new_deleter)
-    -> void {
+auto PrivateObjectData::set_data(
+    void *new_data, std::function<void(void *)> new_deleter) -> void {
   clear();
   data_ = new_data;
   deleter_ = new_deleter;

--- a/src/engine/javascript_core/engine_value.cc
+++ b/src/engine/javascript_core/engine_value.cc
@@ -34,8 +34,8 @@ static auto js_string_to_std_string(JSStringRef value) -> std::string {
 
 // Converting a value into a string first requires copying
 // the value reference into a string reference.
-static auto js_value_to_std_string(JSContextRef context, JSValueRef value)
-    -> std::string {
+static auto js_value_to_std_string(JSContextRef context,
+                                   JSValueRef value) -> std::string {
   JSValueRef exception = nullptr;
   JSStringRef copy = JSValueToStringCopy(context, value, &exception);
   assert(!exception);
@@ -50,8 +50,8 @@ static auto js_value_to_std_string(JSContextRef context, JSValueRef value)
   }
 }
 
-static auto get_current_object(JSContextRef context, JSValueRef value)
-    -> JSObjectRef {
+static auto get_current_object(JSContextRef context,
+                               JSValueRef value) -> JSObjectRef {
   JSValueRef exception = nullptr;
   JSObjectRef object = JSValueToObject(context, value, &exception);
   assert(!exception);
@@ -59,8 +59,8 @@ static auto get_current_object(JSContextRef context, JSValueRef value)
   return object;
 }
 
-static auto get_object_length(JSContextRef context, JSObjectRef object)
-    -> std::size_t {
+static auto get_object_length(JSContextRef context,
+                              JSObjectRef object) -> std::size_t {
   JSValueRef exception = nullptr;
   JSStringRef length_string = JSStringCreateWithUTF8CString("length");
   const double length = JSValueToNumber(
@@ -321,8 +321,8 @@ auto Value::set(const std::string &name, Function cpp_function) -> void {
   JSStringRelease(function_name_ref);
 }
 
-auto Value::private_data(void *data, std::function<void(void *)> deleter)
-    -> void {
+auto Value::private_data(void *data,
+                         std::function<void(void *)> deleter) -> void {
   assert(is_object());
 
   // Get the parent object

--- a/test/engine/engine_binding_test.cc
+++ b/test/engine/engine_binding_test.cc
@@ -8,15 +8,15 @@ static auto is_string(const includejs::Context &context,
 }
 
 // TODO: Add overload that doesn't take arguments
-static auto get_details(const includejs::Context &context, INCLUDEJS_ARGS)
-    -> includejs::Value {
+static auto get_details(const includejs::Context &context,
+                        INCLUDEJS_ARGS) -> includejs::Value {
   includejs::Value result{context.make_object()};
   result.set("version", context.from("1.0.0"));
   return result;
 }
 
-static auto promise_test(const includejs::Context &context, INCLUDEJS_ARGS)
-    -> includejs::Value {
+static auto promise_test(const includejs::Context &context,
+                         INCLUDEJS_ARGS) -> includejs::Value {
   includejs::Promise promise{context.make_promise()};
   promise.resolve(context.from(true));
   return promise.value();


### PR DESCRIPTION
Fixes the formatting errors on macOS CI:
https://github.com/crossnx/includejs/actions/runs/8596937858/job/23554537781?pr=56#step:9:10 by using the same latest ClangFormat version on all platforms.