### PR TITLE
Use version agnostic homebrew prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         if: runner.os == 'linux'
         run: |
           sudo apt-get update --yes
-          sudo apt-get install --yes libjavascriptcoregtk-4.0-dev
+          sudo apt-get install --yes libjavascriptcoregtk-4.1-dev
 
       # See https://github.com/actions/runner-images/issues/8659
       - name: Workaround Clang issue (GNU/Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,14 +83,6 @@ jobs:
         run: |
           sudo apt-get update --yes
           sudo apt-get install --yes libjavascriptcoregtk-4.1-dev
-
-      # See https://github.com/actions/runner-images/issues/8659
-      # - name: Workaround Clang issue (GNU/Linux)
-      #   if: runner.os == 'linux' && matrix.platform.cc == 'clang'
-      #   run: |
-      #     sudo apt-get purge -y g++-13 gcc-13 libstdc++-13-dev
-      #     sudo apt-get install -y --allow-downgrades libstdc++-12-dev libstdc++6=12.* libgcc-s1=12.*
-
       - uses: actions/checkout@v4
       - name: Install dependencies (macOS)
         if: runner.os == 'macos'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,11 @@ jobs:
           sudo apt-get install --yes libjavascriptcoregtk-4.1-dev
 
       # See https://github.com/actions/runner-images/issues/8659
-      - name: Workaround Clang issue (GNU/Linux)
-        if: runner.os == 'linux' && matrix.platform.cc == 'clang'
-        run: |
-          sudo apt-get purge -y g++-13 gcc-13 libstdc++-13-dev
-          sudo apt-get install -y --allow-downgrades libstdc++-12-dev libstdc++6=12.* libgcc-s1=12.*
+      # - name: Workaround Clang issue (GNU/Linux)
+      #   if: runner.os == 'linux' && matrix.platform.cc == 'clang'
+      #   run: |
+      #     sudo apt-get purge -y g++-13 gcc-13 libstdc++-13-dev
+      #     sudo apt-get install -y --allow-downgrades libstdc++-12-dev libstdc++6=12.* libgcc-s1=12.*
 
       - uses: actions/checkout@v4
       - name: Install dependencies (macOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(vendor/noa/cmake/noa.cmake)
 include(cmake/CompilerOptions.cmake)
 
 # C++ standard
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Options
 set(INCLUDEJS_BACKEND "JavaScriptCore" CACHE STRING "The IncludeJS Engine backend")

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CTEST = ctest
 # Options
 PRESET = Debug
 SHARED = OFF
-BACKEND = JavaScriptCore
+BACKEND ?= JavaScriptCore
 
 all: configure compile test
 
@@ -17,7 +17,8 @@ configure: .always
 		-DINCLUDEJS_ENGINE:BOOL=ON \
 		-DINCLUDEJS_TESTS:BOOL=ON \
 		-DINCLUDEJS_DOCS:BOOL=ON \
-		-DBUILD_SHARED_LIBS:BOOL=$(SHARED)
+		-DBUILD_SHARED_LIBS:BOOL=$(SHARED) \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON
 
 compile: .always
 	$(CMAKE) --build ./build --config $(PRESET) --target clang_format

--- a/cmake/FindJavaScriptCore.cmake
+++ b/cmake/FindJavaScriptCore.cmake
@@ -8,7 +8,7 @@ if(NOT JavaScriptCore_FOUND)
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_library(javascript_core INTERFACE IMPORTED)
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(JAVASCRIPTCORE REQUIRED javascriptcoregtk-4.0)
+    pkg_check_modules(JAVASCRIPTCORE REQUIRED javascriptcoregtk-4.1)
     set_property(TARGET javascript_core PROPERTY
       INTERFACE_INCLUDE_DIRECTORIES ${JAVASCRIPTCORE_INCLUDE_DIRS})
     set_property(TARGET javascript_core PROPERTY

--- a/cmake/FindV8.cmake
+++ b/cmake/FindV8.cmake
@@ -5,16 +5,15 @@ if(NOT V8_FOUND)
     # Clang, it is unable to find the V8 library and headers which have been
     # downloaded from Homebrew.
     # Refs: https://github.com/Homebrew/homebrew-core/issues/45061#issuecomment-541420664
-    set(V8_VERSION "12.1.285.24")
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-      set(HOMEBREW_CELLAR "/opt/homebrew/Cellar")
+      set(HOMEBREW_PREFIX "/opt/homebrew/opt/v8")
     elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-      set(HOMEBREW_CELLAR "/usr/local/Cellar")
+      set(HOMEBREW_PREFIX "/usr/local/opt/v8")
     endif()
     target_include_directories(v8
-      INTERFACE "${HOMEBREW_CELLAR}/v8/${V8_VERSION}/include")
+      INTERFACE "${HOMEBREW_PREFIX}/include")
     target_link_directories(v8
-      INTERFACE "${HOMEBREW_CELLAR}/v8/${V8_VERSION}/lib")
+      INTERFACE "${HOMEBREW_PREFIX}/lib")
     target_link_libraries(v8 INTERFACE "-lv8")
     target_link_libraries(v8 INTERFACE "-lv8_libplatform")
     target_compile_definitions(v8


### PR DESCRIPTION
- Use version agnostic homebrew prefix
- Recent versions of v8 requires C++ 20
- Accept V8 backend as option from make
- Export compile commands from cmake